### PR TITLE
[AI] preparation for accretion disc supply effect

### DIFF
--- a/default/AI/AIDependencies.py
+++ b/default/AI/AIDependencies.py
@@ -52,7 +52,9 @@ supply_by_size = {fo.planetSize.tiny: 2,
                   fo.planetSize.gasGiant: -1
                   }
 
-SUPPLY_MOD_SPECIALS = {'WORLDTREE_SPECIAL': {-1: 1}}
+SUPPLY_MOD_SPECIALS = {'WORLDTREE_SPECIAL': {-1: 1},
+                       'ACCRETION_DISC_EFFECTS': {-1: 1},
+                       }
 
 # building supply bonuses are keyed by planet size; key -1 stands for any planet size
 building_supply = {"BLD_IMPERIAL_PALACE": {-1: 2},

--- a/default/AI/ColonisationAI.py
+++ b/default/AI/ColonisationAI.py
@@ -916,7 +916,7 @@ def evaluate_planet(planet_id, mission_type, spec_name, empire, detail=None):
                          for psize in [-1, planet.size] for bld_type in bld_types)
     planet_supply += sum(AIDependencies.SUPPLY_MOD_SPECIALS[_special].get(int(psize), 0)
                          for psize in [-1, planet.size] for _special in
-                         set(planet.specials).intersection(AIDependencies.SUPPLY_MOD_SPECIALS))
+                         set(planet.specials).union(system.specials).intersection(AIDependencies.SUPPLY_MOD_SPECIALS))
 
     common_grades = {'NO': 0.0, 'BAD': 0.5, 'GOOD': 1.5, 'GREAT': 2.0, 'ULTIMATE': 4.0}
     ind_tag_mod = common_grades.get(get_ai_tag_grade(tag_list, "INDUSTRY"), 1.0)


### PR DESCRIPTION
Sloth, this does not actually adapt the AI for the field as you have it currently written.  There may be some reasonably efficient way I don't know about for the AI to determine which planets lie within such a field, but as far as I can see the AI would have to individually check every object to see if it is in the field.  That is surely something we need to change at some point, but I'm not up for that right now.

So, if you are game to change the structure here so that your field applies a "ACCRETION_DISC_EFFECTS" special to the system (or to the planets if you prefer, but not to both), then this PR should handle it fine.  Theoretically you could leave the actual effects with the Field, and have the special be essentially just a flag for the AI, but for future maintenance between the AI and the special it would probably be best for the actual effects to be in the special.
